### PR TITLE
Add docker compose for quarkus service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  quarkus-service-template:
+    build:
+      context: ./quarkus-service-template
+      dockerfile: src/main/docker/Dockerfile.jvm
+    ports:
+      - "8100:8100"


### PR DESCRIPTION
## Summary
- add docker-compose.yml to build and run quarkus-service-template image and expose port 8100

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin io.quarkus.platform:quarkus-maven-plugin:3.26.2 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68bff53a117c8324a4b0d50761f7558d