### PR TITLE
Use anime IDs in sharacter model

### DIFF
--- a/core/src/main/java/model/Sharacter.java
+++ b/core/src/main/java/model/Sharacter.java
@@ -4,13 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import javax.json.bind.annotation.JsonbTransient;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Sharacter extends BaseEntity {
-    @JsonbTransient
-    private Anime anime;
+    /**
+     * Identifier of the {@link Anime} this sharacter belongs to. Only the id is
+     * stored to avoid holding a full object reference.
+     */
+    private Long animeId;
 }


### PR DESCRIPTION
## Summary
- store only animeId on Sharacter instead of Anime object
- update SharacterService to use animeId and manage anime's character list

## Testing
- `mvn -q test` *(failed: Unresolveable build extension / network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c03b918bbc83249f366085115b74e8