### PR TITLE
feat: add reactive repositories and seed database

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,6 +71,15 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-reactive-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>1.0.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/model/Anime.java
+++ b/core/src/main/java/model/Anime.java
@@ -1,8 +1,8 @@
 package model;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,8 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
+@Entity
+@Table(name = "anime")
 public class Anime extends BaseEntity {
     private LocalDate release;
-    private List<Sharacter> sharacters = new ArrayList<>();
 }

--- a/core/src/main/java/model/BaseEntity.java
+++ b/core/src/main/java/model/BaseEntity.java
@@ -2,6 +2,11 @@ package model;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +14,12 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@MappedSuperclass
 public abstract class BaseEntity {
-    private int id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
     private String name;
     private String description;
     private String image;

--- a/core/src/main/java/model/Sharacter.java
+++ b/core/src/main/java/model/Sharacter.java
@@ -1,5 +1,9 @@
 package model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -9,10 +13,13 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
+@Entity
+@Table(name = "sharacter")
 public class Sharacter extends BaseEntity {
     /**
      * Identifier of the {@link Anime} this sharacter belongs to. Only the id is
      * stored to avoid holding a full object reference.
      */
-    private int animeId;
+    @Column(name = "anime_id")
+    private Integer animeId;
 }

--- a/core/src/main/java/repository/AnimeRepository.java
+++ b/core/src/main/java/repository/AnimeRepository.java
@@ -1,0 +1,10 @@
+package repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.reactive.panache.PanacheRepositoryBase;
+import model.Anime;
+
+@ApplicationScoped
+public class AnimeRepository implements PanacheRepositoryBase<Anime, Integer> {
+}

--- a/core/src/main/java/repository/SharacterRepository.java
+++ b/core/src/main/java/repository/SharacterRepository.java
@@ -1,0 +1,10 @@
+package repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.reactive.panache.PanacheRepositoryBase;
+import model.Sharacter;
+
+@ApplicationScoped
+public class SharacterRepository implements PanacheRepositoryBase<Sharacter, Integer> {
+}

--- a/core/src/main/java/service/DataSeeder.java
+++ b/core/src/main/java/service/DataSeeder.java
@@ -1,0 +1,66 @@
+package service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import com.github.javafaker.Faker;
+
+import io.quarkus.hibernate.reactive.panache.Panache;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.runtime.configuration.ProfileManager;
+import model.Anime;
+import model.Sharacter;
+import repository.AnimeRepository;
+import repository.SharacterRepository;
+
+@ApplicationScoped
+public class DataSeeder {
+
+    @Inject AnimeRepository animeRepository;
+    @Inject SharacterRepository sharacterRepository;
+
+    void init(@Observes StartupEvent event) {
+        if (!"dev".equals(ProfileManager.getActiveProfile())) {
+            return;
+        }
+
+        Faker faker = new Faker();
+
+        Panache.withTransaction(sharacterRepository::deleteAll).await().indefinitely();
+        Panache.withTransaction(animeRepository::deleteAll).await().indefinitely();
+
+        List<Anime> animes = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Anime anime = new Anime();
+            anime.setName(faker.anime().title());
+            anime.setDescription(faker.lorem().sentence());
+            anime.setImage(faker.internet().image());
+            anime.setRelease(LocalDate.now().minusDays(faker.number().numberBetween(0, 3650)));
+            anime.setCreatedAt(LocalDateTime.now());
+            anime.setUpdatedAt(LocalDateTime.now());
+            animes.add(anime);
+        }
+        Panache.withTransaction(() -> animeRepository.persist(animes)).await().indefinitely();
+
+        Random random = new Random();
+        List<Sharacter> sharacters = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            Sharacter sharacter = new Sharacter();
+            sharacter.setName(faker.anime().character());
+            sharacter.setDescription(faker.lorem().sentence());
+            sharacter.setImage(faker.internet().avatar());
+            sharacter.setAnimeId(animes.get(random.nextInt(animes.size())).getId());
+            sharacter.setCreatedAt(LocalDateTime.now());
+            sharacter.setUpdatedAt(LocalDateTime.now());
+            sharacters.add(sharacter);
+        }
+        Panache.withTransaction(() -> sharacterRepository.persist(sharacters)).await().indefinitely();
+    }
+}


### PR DESCRIPTION
## Summary
- add reactive Panache repositories for anime and sharacter
- seed PostgreSQL with Faker-generated anime and sharacter data on dev startup
- enable Hibernate reactive and Faker dependencies

## Testing
- `mvn -q -pl core package` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.26.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1782928c0832486ec2fc11f2b399f