### PR TITLE
Add DTOs for anime and sharacter with relational mapping

### DIFF
--- a/core/src/main/java/dto/AnimeDto.java
+++ b/core/src/main/java/dto/AnimeDto.java
@@ -1,0 +1,23 @@
+package dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnimeDto {
+    private Integer id;
+    private String name;
+    private String description;
+    private String image;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDate release;
+    private List<SharacterDto> sharacters;
+}

--- a/core/src/main/java/dto/SharacterDto.java
+++ b/core/src/main/java/dto/SharacterDto.java
@@ -1,0 +1,20 @@
+package dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SharacterDto {
+    private Integer id;
+    private String name;
+    private String description;
+    private String image;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private AnimeDto anime;
+}

--- a/core/src/main/java/mapper/DtoMapper.java
+++ b/core/src/main/java/mapper/DtoMapper.java
@@ -1,0 +1,50 @@
+package mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import dto.AnimeDto;
+import dto.SharacterDto;
+import model.Anime;
+import model.Sharacter;
+
+public class DtoMapper {
+    public static AnimeDto toAnimeDto(Anime anime) {
+        if (anime == null) {
+            return null;
+        }
+        List<SharacterDto> sharacters = null;
+        if (anime.getSharacters() != null) {
+            sharacters = anime.getSharacters().stream()
+                    .map(DtoMapper::toSharacterDtoWithoutAnime)
+                    .collect(Collectors.toList());
+        }
+        return new AnimeDto(anime.getId(), anime.getName(), anime.getDescription(), anime.getImage(),
+                anime.getCreatedAt(), anime.getUpdatedAt(), anime.getRelease(), sharacters);
+    }
+
+    public static AnimeDto toAnimeDtoWithoutSharacters(Anime anime) {
+        if (anime == null) {
+            return null;
+        }
+        return new AnimeDto(anime.getId(), anime.getName(), anime.getDescription(), anime.getImage(),
+                anime.getCreatedAt(), anime.getUpdatedAt(), anime.getRelease(), null);
+    }
+
+    public static SharacterDto toSharacterDto(Sharacter sharacter) {
+        if (sharacter == null) {
+            return null;
+        }
+        return new SharacterDto(sharacter.getId(), sharacter.getName(), sharacter.getDescription(),
+                sharacter.getImage(), sharacter.getCreatedAt(), sharacter.getUpdatedAt(),
+                toAnimeDtoWithoutSharacters(sharacter.getAnime()));
+    }
+
+    public static SharacterDto toSharacterDtoWithoutAnime(Sharacter sharacter) {
+        if (sharacter == null) {
+            return null;
+        }
+        return new SharacterDto(sharacter.getId(), sharacter.getName(), sharacter.getDescription(),
+                sharacter.getImage(), sharacter.getCreatedAt(), sharacter.getUpdatedAt(), null);
+    }
+}

--- a/core/src/main/java/model/Anime.java
+++ b/core/src/main/java/model/Anime.java
@@ -1,7 +1,12 @@
 package model;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import lombok.AllArgsConstructor;
@@ -17,4 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "anime")
 public class Anime extends BaseEntity {
     private LocalDate release;
+
+    @OneToMany(mappedBy = "anime", fetch = FetchType.EAGER)
+    private List<Sharacter> sharacters = new ArrayList<>();
 }

--- a/core/src/main/java/model/Sharacter.java
+++ b/core/src/main/java/model/Sharacter.java
@@ -1,7 +1,8 @@
 package model;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import lombok.AllArgsConstructor;
@@ -16,10 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "sharacter")
 public class Sharacter extends BaseEntity {
-    /**
-     * Identifier of the {@link Anime} this sharacter belongs to. Only the id is
-     * stored to avoid holding a full object reference.
-     */
-    @Column(name = "anime_id")
-    private Integer animeId;
+    @ManyToOne
+    @JoinColumn(name = "anime_id")
+    private Anime anime;
 }

--- a/core/src/main/java/resource/AnimeResource.java
+++ b/core/src/main/java/resource/AnimeResource.java
@@ -1,6 +1,7 @@
 package resource;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.DELETE;
@@ -12,6 +13,8 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import dto.AnimeDto;
+import mapper.DtoMapper;
 import model.Anime;
 import service.AnimeService;
 
@@ -28,26 +31,32 @@ public class AnimeResource {
     }
 
     @GET
-    public Uni<List<Anime>> all() {
-        return animeService.findAll();
+    public Uni<List<AnimeDto>> all() {
+        return animeService.findAll()
+                .onItem().transform(animes -> animes.stream()
+                        .map(DtoMapper::toAnimeDto)
+                        .collect(Collectors.toList()));
     }
 
     @GET
     @Path("/{id}")
-    public Uni<Anime> get(@PathParam("id") int id) {
-        return animeService.findById(id);
+    public Uni<AnimeDto> get(@PathParam("id") int id) {
+        return animeService.findById(id)
+                .onItem().transform(DtoMapper::toAnimeDto);
     }
 
     @POST
-    public Uni<Anime> create(Anime anime) {
-        return animeService.save(anime);
+    public Uni<AnimeDto> create(Anime anime) {
+        return animeService.save(anime)
+                .onItem().transform(DtoMapper::toAnimeDto);
     }
 
     @PUT
     @Path("/{id}")
-    public Uni<Anime> update(@PathParam("id") int id, Anime anime) {
+    public Uni<AnimeDto> update(@PathParam("id") int id, Anime anime) {
         anime.setId(id);
-        return animeService.save(anime);
+        return animeService.save(anime)
+                .onItem().transform(DtoMapper::toAnimeDto);
     }
 
     @DELETE

--- a/core/src/main/java/resource/SharacterResource.java
+++ b/core/src/main/java/resource/SharacterResource.java
@@ -1,6 +1,7 @@
 package resource;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.DELETE;
@@ -12,6 +13,8 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import dto.SharacterDto;
+import mapper.DtoMapper;
 import model.Sharacter;
 import service.SharacterService;
 
@@ -28,26 +31,32 @@ public class SharacterResource {
     }
 
     @GET
-    public Uni<List<Sharacter>> all() {
-        return sharacterService.findAll();
+    public Uni<List<SharacterDto>> all() {
+        return sharacterService.findAll()
+                .onItem().transform(sharacters -> sharacters.stream()
+                        .map(DtoMapper::toSharacterDto)
+                        .collect(Collectors.toList()));
     }
 
     @GET
     @Path("/{id}")
-    public Uni<Sharacter> get(@PathParam("id") int id) {
-        return sharacterService.findById(id);
+    public Uni<SharacterDto> get(@PathParam("id") int id) {
+        return sharacterService.findById(id)
+                .onItem().transform(DtoMapper::toSharacterDto);
     }
 
     @POST
-    public Uni<Sharacter> create(Sharacter sharacter) {
-        return sharacterService.save(sharacter);
+    public Uni<SharacterDto> create(Sharacter sharacter) {
+        return sharacterService.save(sharacter)
+                .onItem().transform(DtoMapper::toSharacterDto);
     }
 
     @PUT
     @Path("/{id}")
-    public Uni<Sharacter> update(@PathParam("id") int id, Sharacter sharacter) {
+    public Uni<SharacterDto> update(@PathParam("id") int id, Sharacter sharacter) {
         sharacter.setId(id);
-        return sharacterService.save(sharacter);
+        return sharacterService.save(sharacter)
+                .onItem().transform(DtoMapper::toSharacterDto);
     }
 
     @DELETE


### PR DESCRIPTION
## Summary
- map Anime entity to include its characters
- expose DTOs for Anime and Sharacter, returning related data in APIs
- convert REST resources to return DTOs using new mapper

## Testing
- `mvn -q test` *(fails: could not resolve dependencies: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1897d78c0832480d0d6d42731d23d